### PR TITLE
Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 node_modules
 build
-.tmp
-.sass-cache
-bower_components
-test/bower_components
+test/.tmp

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ viewer.on('not-connected', showOfflineMessage);
 # Developing
 
 Dependencies go into `build/package.json` so they get installed from production.
+
+Commands:
+
+`npm run build` - Builds
+`npm run test` - Runs tests 

--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftlabs-screens-viewer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Connects to a screens server with websockets and fires events on url change.",
   "main": "./index.js",
   "author": "",

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function Viewer(host) {
 		}
 
 
-		const {nextItem, nextItemIndex} = (function() {
+		const nextItem = (() => {
 
 			for (let i=0,l = this.data.items.length; i<l; i++) {
 				const item = this.data.items[i];
@@ -78,10 +78,7 @@ function Viewer(host) {
 					moment(item.dateTimeSchedule, 'x').isBefore(date) ||
 					moment(item.dateTimeSchedule, 'x').isSame(date)
 				) {
-					return {
-						nextItem: item,
-						nextItemIndex: i
-					};
+					return item;
 				}
 			}
 		})();
@@ -89,11 +86,11 @@ function Viewer(host) {
 		const newUrl = nextItem ? nextItem.url : undefined;
 
 		// Only update if the old url and new url are different
-		if (!(Object.is(newUrl, url))) {
+		if (newUrl !== url) {
 			removeActiveFlag();
 			url = newUrl;
 			if (newUrl) {
-				this.data.items[nextItemIndex].active = true;
+				nextItem.active = true;
 				this.emit('change', url);
 			} else {
 				if (this.ready()) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ function Viewer(host) {
 	};
 
 	this.connectionState = false;
-	this.data = JSON.parse(localStorage.getItem(LSKEY) || '{"item":[]}');
+	this.data = JSON.parse(localStorage.getItem(LSKEY) || '{"items":[]}');
 
 	// Every second, check whether the URL needs to be changed
 	setInterval(poll.bind(this), 1000);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 /* global io */
 
+require("babel-polyfill");
 const moment = require('moment');
 const EventEmitter = require('events');
 const util = require('util');
@@ -25,7 +26,7 @@ function Viewer(host) {
 	socket.on('requestUpdate', () => this.syncUp());
 
 	socket.on('update', data => {
-		console.log('Received update', data.items.length, data);
+		console.log('Received update', data);
 		this.update(data);
 	});
 
@@ -43,8 +44,6 @@ function Viewer(host) {
 			socket.emit('heartbeat');
 		}, 3000);
 	});
-
-	this.on('change', this.syncUp);
 
 	console.log('Initialising socket.io...');
 
@@ -93,6 +92,7 @@ function Viewer(host) {
 					this.emit('not-connected');
 				}
 			}
+			this.syncUp();
 		}
 	};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 /* global io */
 
-require("babel-polyfill");
 const moment = require('moment');
 const EventEmitter = require('events');
 const util = require('util');
@@ -69,12 +68,23 @@ function Viewer(host) {
 			dirty = true;
 		}
 
-		var nextItemIndex;
-		const nextItem = this.data.items.find(function (item, index) {
-			nextItemIndex = index;
-			return moment(item.dateTimeSchedule, 'x').isBefore(date) ||
-				moment(item.dateTimeSchedule, 'x').isSame(date);
-		});
+
+		const {nextItem, nextItemIndex} = (function() {
+
+			for (let i=0,l = this.data.items.length; i<l; i++) {
+				const item = this.data.items[i];
+
+				if (
+					moment(item.dateTimeSchedule, 'x').isBefore(date) ||
+					moment(item.dateTimeSchedule, 'x').isSame(date)
+				) {
+					return {
+						nextItem: item,
+						nextItemIndex: i
+					};
+				}
+			}
+		})();
 
 		const newUrl = nextItem ? nextItem.url : undefined;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftlabs-screens-viewer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Connects to a screens server with websockets and fires events on url change.",
   "scripts": {
     "build": "babel ./lib/ -d ./build/",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "Connects to a screens server with websockets and fires events on url change.",
   "scripts": {
     "build": "babel ./lib/ -d ./build/",
-    "build-test": "mkdir test/.tmp; browserify test/client.js -o test/.tmp/client.js",
-    "test": "npm run build; npm run build-test; mocha-phantomjs ./test/test.html --ignore-ssl-errors=true",
+    "build-test": "mkdir -p test/.tmp; browserify ./build/ -o test/.tmp/client.js -s Viewer",
+    "test": "npm run build; npm run build-test; node ./test/server.js & sleep 1; mocha-phantomjs http://localhost:3000/test.html; kill $!; echo Killed $!;",
     "deploy": "npm run build; git diff --quiet HEAD || exit 1; PKG_VERSION=`npm version --no-git-tag-version ${1-'patch'} | cut -c 2-`; cd build/; npm version --no-git-tag-version $PKG_VERSION; cd -; git commit -am v$PKG_VERSION; git-directory-deploy --directory build --branch production; git checkout production; git tag v$PKG_VERSION; git push --tags; git checkout -"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
+    "express": "^4.13.3",
     "git-directory-deploy": "^1.3.0",
     "mocha": "^2.3.4",
     "mocha-phantomjs": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "description": "Connects to a screens server with websockets and fires events on url change.",
   "scripts": {
     "build": "babel ./lib/ -d ./build/",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "build-test": "mkdir test/.tmp; browserify test/client.js -o test/.tmp/client.js",
+    "test": "npm run build; npm run build-test; mocha-phantomjs ./test/test.html --ignore-ssl-errors=true",
     "deploy": "npm run build; git diff --quiet HEAD || exit 1; PKG_VERSION=`npm version --no-git-tag-version ${1-'patch'} | cut -c 2-`; cd build/; npm version --no-git-tag-version $PKG_VERSION; cd -; git commit -am v$PKG_VERSION; git-directory-deploy --directory build --branch production; git checkout production; git tag v$PKG_VERSION; git push --tags; git checkout -"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
-    "git-directory-deploy": "^1.3.0"
+    "git-directory-deploy": "^1.3.0",
+    "mocha": "^2.3.4",
+    "mocha-phantomjs": "^4.0.1",
+    "socket.io": "^1.3.7"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Connects to a screens server with websockets and fires events on url change.",
   "scripts": {
     "build": "babel ./lib/ -d ./build/",
-    "build-test": "mkdir -p test/.tmp; browserify ./build/ -o test/.tmp/client.js -s Viewer",
+    "build-test": "mkdir -p test/.tmp; browserify ./build/ -o ./test/.tmp/client.js -s Viewer",
     "test": "npm run build; npm run build-test; node ./test/server.js & sleep 1; mocha-phantomjs http://localhost:3000/test.html; kill $!; echo Killed $!;",
     "deploy": "npm run build; git diff --quiet HEAD || exit 1; PKG_VERSION=`npm version --no-git-tag-version ${1-'patch'} | cut -c 2-`; cd build/; npm version --no-git-tag-version $PKG_VERSION; cd -; git commit -am v$PKG_VERSION; git-directory-deploy --directory build --branch production; git checkout production; git tag v$PKG_VERSION; git push --tags; git checkout -"
   },

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,4 @@
+'use strict';
+/* global mocha, describe, it */
+
+window.Viewer = require('../build/index.js');

--- a/test/client.js
+++ b/test/client.js
@@ -1,4 +1,0 @@
-'use strict';
-/* global mocha, describe, it */
-
-window.Viewer = require('../build/index.js');

--- a/test/server.js
+++ b/test/server.js
@@ -10,7 +10,11 @@ const ioServer = require('socket.io').listen(server).of('/screens');
 ioServer.on('connection', function(socket) {
 
 	// when a request is recieved echo it back
-	socket.on('echo', data => socket.emit(data._action, data));
+	socket.on('echo', function (data) {
+		const action = data._action;
+		delete data._action;
+		socket.emit(action, data);
+	});
 });
 
 app.use(express.static(__dirname));

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const ioServer = require('socket.io')().of('/screens');
+ioServer.on('connection', function(socket) {
+	console.log(socket);
+});

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,18 @@
 'use strict';
 
-const ioServer = require('socket.io')().of('/screens');
+const express = require('express');
+const app = express();
+const http = require('http');
+
+const server = http.createServer(app);
+const ioServer = require('socket.io').listen(server).of('/screens');
+
 ioServer.on('connection', function(socket) {
-	console.log(socket);
+
+	// when a request is recieved echo it back
+	socket.on('echo', data => socket.emit(data._action, data));
 });
+
+app.use(express.static(__dirname));
+
+server.listen(3000);

--- a/test/test.html
+++ b/test/test.html
@@ -1,7 +1,6 @@
 <html>
 	<head>
 		<meta charset="utf-8">
-		<!-- encoding must be set for mocha's special characters to render properly -->
         <link href="http://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css" rel="stylesheet" />
 	</head>
 	<body>

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,22 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<!-- encoding must be set for mocha's special characters to render properly -->
+        <link href="http://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css" rel="stylesheet" />
+	</head>
+	<body>
+		<div id="mocha"></div>
+        <script src="http://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.js"></script>
+        <script src="http://cdn.socket.io/socket.io-1.3.7.js"></script>
+        <script>
+            /*global mocha*/
+            mocha.setup('bdd');
+        </script>
+        <script src=".tmp/client.js"></script>
+		<script src="tests/viewer.js"></script>
+		<script>
+            /*global mocha*/
+			mocha.run();
+		</script>
+	</body>
+</html>

--- a/test/test.html
+++ b/test/test.html
@@ -7,13 +7,14 @@
 	<body>
 		<div id="mocha"></div>
         <script src="http://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.js"></script>
+        <script src="http://cdnjs.cloudflare.com/ajax/libs/chai/3.4.1/chai.min.js"></script>
         <script src="http://cdn.socket.io/socket.io-1.3.7.js"></script>
         <script>
             /*global mocha*/
             mocha.setup('bdd');
         </script>
         <script src=".tmp/client.js"></script>
-		<script src="tests/viewer.js"></script>
+        <script src="tests/viewer.js"></script>
 		<script>
             /*global mocha*/
 			mocha.run();

--- a/test/tests/viewer.js
+++ b/test/tests/viewer.js
@@ -1,0 +1,12 @@
+'use strict';
+/* global Viewer, describe, it */
+
+describe('Connect to the server via io', function(){
+
+	it('Should connect via sockets on /screens', function(done){
+
+		var viewer = new Viewer('http://localhost');
+		console.log(viewer.data);
+		done();
+	});
+});

--- a/test/tests/viewer.js
+++ b/test/tests/viewer.js
@@ -1,12 +1,38 @@
 'use strict';
-/* global Viewer, describe, it */
+/* global Viewer, describe, it, chai */
+var expect = chai.expect;
+var viewer;
+var mockAPIs = {
+	reload: {}
+};
+
+function mockAPI(action) {
+	var data = Object.create(mockAPIs[action]);
+	data._action = action;
+	viewer.socket.emit('echo', data);
+}
 
 describe('Connect to the server via io', function(){
 
 	it('Should connect via sockets on /screens', function(done){
 
-		var viewer = new Viewer('http://localhost');
-		console.log(viewer.data);
-		done();
+		viewer = new Viewer('http://localhost:3000');
+		var i = 0;
+		(function connect() {
+
+			// wait for 200ms for server to connect
+			if (!viewer.connectionState && i++ < 10) {
+				return setTimeout(connect, 20);
+			}
+			expect(viewer.connectionState).to.be.true;
+			done();
+		})();
+	});
+});
+
+describe('API', function () {
+	it('Should reload when recieves reload', function (done) {
+		viewer.on('reload', function() { done() });
+		mockAPI('reload');
 	});
 });

--- a/test/tests/viewer.js
+++ b/test/tests/viewer.js
@@ -74,6 +74,10 @@ describe('API', function () {
 	});
 
 	it('Should change the urls which expire.', function (done) {
+
+		// it needs a smidge more time
+		this.timeout(2500);
+
 		mockAPIs.updateUrl.items[0].expires = Date.now() + 1000;
 		mockAPIs.updateUrl.items[0].url = 'https://ft.com';
 		mockAPI('updateUrl');

--- a/test/tests/viewer.js
+++ b/test/tests/viewer.js
@@ -1,15 +1,29 @@
 'use strict';
-/* global Viewer, describe, it, chai */
+/* global Viewer, describe, it, chai, afterEach */
 var expect = chai.expect;
 var viewer;
 var mockAPIs = {
-	reload: {}
+	reload: {
+		_action: 'reload'
+	},
+	updateId: {
+		_action: 'update',
+		id: 12345,
+		name: 'Dummy Test Viewer',
+		items: []
+	},
+	updateUrl: {
+		_action: 'update',
+		id: 12345,
+		name: 'Dummy Test Viewer',
+		items: [
+			{url: 'https://google.com'}
+		]
+	}
 };
 
 function mockAPI(action) {
-	var data = Object.create(mockAPIs[action]);
-	data._action = action;
-	viewer.socket.emit('echo', data);
+	viewer.socket.emit('echo', mockAPIs[action]);
 }
 
 describe('Connect to the server via io', function(){
@@ -17,22 +31,104 @@ describe('Connect to the server via io', function(){
 	it('Should connect via sockets on /screens', function(done){
 
 		viewer = new Viewer('http://localhost:3000');
-		var i = 0;
-		(function connect() {
-
-			// wait for 200ms for server to connect
-			if (!viewer.connectionState && i++ < 10) {
-				return setTimeout(connect, 20);
-			}
+		viewer.socket.on('connect', function () {
 			expect(viewer.connectionState).to.be.true;
+			expect(viewer.data).to.not.be.undefined;
 			done();
-		})();
+		});
 	});
 });
 
 describe('API', function () {
+
+	// remove all listeners
+	afterEach(function() {
+		viewer.removeAllListeners('change');
+		viewer.removeAllListeners('update');
+		viewer.removeAllListeners('reload');
+	});
+
 	it('Should reload when recieves reload', function (done) {
-		viewer.on('reload', function() { done() });
+		viewer.once('reload', function() { done() });
 		mockAPI('reload');
+	});
+
+	it('Should not update when only id updated', function (done) {
+		function err() { throw Error('Should not change, no items added.') }
+		viewer.once('change', err);
+		mockAPI('updateId');
+		viewer.socket.once('update', function () {
+			setTimeout(function() {
+				viewer.removeListener('change', err);
+				done();
+			}, 200);
+		});
+	});
+
+	it('Should update when the url list is updated', function (done) {
+		mockAPI('updateUrl');
+		viewer.once('change', function (url) {
+			expect(url).to.equal('https://google.com');
+			done();
+		});
+	});
+
+	it('Should change the urls which expire.', function (done) {
+		mockAPIs.updateUrl.items[0].expires = Date.now() + 1000;
+		mockAPIs.updateUrl.items[0].url = 'https://ft.com';
+		mockAPI('updateUrl');
+		viewer.once('change', function (url) {
+			expect(url).to.equal('https://ft.com');
+			viewer.once('change', function (url) {
+
+				// Expect it to show the empty-screen page since there are no others
+				expect(url).to.match(/\/generators\/empty-screen\?id=12345$/);
+
+				// GetUrl should be undefined because the current page as sent by the server is undefined
+				expect(viewer.getUrl()).to.be.undefined;
+				done();
+			});
+		});
+	});
+
+	it('Should show scheduled pages at the correct time.', function (done) {
+
+		// this will take at most one minute as it succeeds when the clock ticks over
+		this.timeout(61000);
+
+		// schedule it for the next time a minute happens
+		// since the that is how the schedules are set on the admin page
+		// and the viewer rolls down the current time to the nearest minute
+		var scheduleTime = new Date();
+		scheduleTime.setSeconds(0);
+		scheduleTime.setMilliseconds(0);
+		scheduleTime = scheduleTime.getTime() + 60000;
+
+		delete mockAPIs.updateUrl.items[0].expires;
+		mockAPIs.updateUrl.items[0].dateTimeSchedule = scheduleTime;
+		mockAPIs.updateUrl.items[0].url = 'https://google.com';
+		viewer.once('change', function (url) {
+			expect(url).to.equal('https://google.com');
+			if (Date.now() > mockAPIs.updateUrl.items[0].dateTimeSchedule) {
+				done();
+			} else {
+				throw Error('Updated too soon.');
+			}
+		});
+		mockAPI('updateUrl');
+	});
+
+	it('Should not refresh the page if the url did not change', function (done) {
+		delete mockAPIs.updateUrl.items[0].dateTimeSchedule;
+		viewer.once('change', function () {
+			throw Error('change was fired even though url did not change.');
+		});
+		viewer.socket.on('update', function () {
+
+			// Make sure no change has happened after an update has been recieved.
+			setTimeout(done, 200);
+		});
+		mockAPI('updateUrl');
+		done();
 	});
 });


### PR DESCRIPTION
Can, @railsagainstignorance @JakeChampion and @seanmtracey, take a look. 

The tests can take a little long to run because due to the nature of scheduling it requires for us to wait for the minute hand to change for one of the tests. 

They also raised a few of small issues which I have fixed:
1. if you ran viewer.removeAllListeners('change') it would stop syncing up.
2. if you made an update with no item array e.g. `{id:12345}` rather than `{id:12345, items: []}` it would error.
3. if you ran it on a browser without native `Array.find` it would error.

To run the tests:

```
npm install
npm run test
```

The tests work by:
1. Compiling the libary to ES5 (so the distribution version is up to date)
2. Builds a standalone version of the ES5 library using browserify
3. An express http server is started to serve the tests and provide a sockets.io echo server.
4. Phantomjs is started and loads up the test html page from the http server.
5. Mocha and Chai are pulled down from the cdn
6. The tests then use the socket echo to spoof api responses and test for the correct response.
