### PR TITLE
Async storage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global io, localStorage */
+/* global io, dataStorage */
 
 const moment = require('moment');
 const EventEmitter = require('events');
@@ -7,147 +7,57 @@ const util = require('util');
 
 const LSKEY = 'viewerData_v2';
 
-function Viewer(host) {
+function Viewer(host, storageOption) {
 	EventEmitter.call(this);
 
-	const socket = io.connect(host + '/screens');
-	let url;
+	this.host = host;
+	this.dataStorage = storageOption;
+	
+	if(this.dataStorage.dataKey === undefined || this.dataStorage.dataKey === ""){
+		this.dataStorage.dataKey = LSKEY;
+	}
+	this.url;
 
 	// Returns the default url for generators, returns null if offline
 	this.getDefaultUrl = function getDefaultUrl() {
 		return host + '/generators/empty-screen?id=' + this.data.id;
 	};
 
-	this.getUrl = () => url;
-
-	this.socket = socket;
-
-	socket.on('requestUpdate', () => this.syncUp());
-
-	socket.on('update', data => {
-		console.log('Received update: ' + JSON.stringify(data, null, '  '));
-		this.update(data);
-	});
-
-	socket.on('reload', () => this.emit('reload'));
-
-	socket.on('connect', () => this.connectionState = true );
-
-	socket.on('reassign', data => {
-
-		console.log('Reassign: ' + JSON.stringify(data, null, '  '));
-
-		const currentData = this.getData();
-
-		if (currentData.id === data.id && currentData.idUpdated === data.idUpdated) {
-
-			const newData = Object.assign({}, currentData);
-			newData.id = data.newID;
-
-			this.update(newData);
-			this.syncUp();
-		}
-
-	});
-
-
-	socket.on('disconnect', () => {
-		socket.io.reconnect();
-		this.connectionState = false;
-	});
-
-	socket.on('heartbeat', function () {
-		setTimeout(function () {
-			socket.emit('heartbeat');
-		}, 3000);
-	});
-
-	console.log('Initialising socket.io...');
-
-	const removeActiveFlag = () => {
-		this.data.items = this.data.items.map(function (item) {
-			item.active = false;
-			return item;
-		});
-	};
-
-	const poll = () => {
-
-		const date = new Date();
-		date.setSeconds(0);
-		date.setMilliseconds(0);
-
-		const amountOfItems = this.data.items.length;
-
-		this.data.items = this.data.items.filter(function(item) {
-			return (!item.expires || (new Date(item.expires)) > (new Date()));
-		});
-
-		const nextItem = (() => {
-
-			for (let i=0,l = this.data.items.length; i<l; i++) {
-				const item = this.data.items[i];
-
-				if (
-					moment(item.dateTimeSchedule, 'x').isBefore(date) ||
-					moment(item.dateTimeSchedule, 'x').isSame(date)
-				) {
-					return item;
-				}
-			}
-		})();
-
-		const newUrl = nextItem ? nextItem.url : undefined;
-
-		// Only update if the old url and new url are different
-		if (newUrl !== url) {
-			removeActiveFlag();
-			url = newUrl;
-			if (newUrl) {
-				nextItem.active = true;
-				this.emit('change', url);
-			} else {
-				if (this.ready()) {
-					this.emit('change', this.getDefaultUrl());
-				} else {
-					this.emit('not-connected');
-				}
-			}
-
-			this.syncUp();
-		} else if (amountOfItems !== this.data.items.length) {
-			this.syncUp();
-		}
-	};
+	this.getUrl = () => this.url;
 
 	this.connectionState = false;
-	this.data = this.loadData();
-
-	// Every second, check whether the URL needs to be changed
-	setInterval(poll.bind(this), 1000);
 }
 util.inherits(Viewer, EventEmitter);
 
-Viewer.prototype.loadData = function loadData() {
-	return JSON.parse(localStorage.getItem(LSKEY) || '{"items":[]}');
+Viewer.prototype.loadData = function loadData(callback) {
+	
+	this.dataStorage.getItem(this.dataStorage.dataKey, function(d){
+		if(d === null){
+			this.data = {"items":[]};
+		} else {
+			this.data = JSON.parse(d["viewerData_v2"]);				
+		}
+		console.log(this.data, this);
+		callback(d);
+	}.bind(this) );
+	
 }
 
-Viewer.prototype.saveData = function saveData() {
-	localStorage.setItem(LSKEY, JSON.stringify(this.data));
+Viewer.prototype.saveData = function saveData(data, callback) {
+	// dataStorage.setItem(dataStorage.dataKey, JSON.stringify(this.data));
+	this.dataStorage.setItem(this.dataStorage.dataKey, data, callback);
+	
 }
 
 module.exports = Viewer;
 
 Viewer.prototype.update = function update(newData) {
 
+	console.log("Update called");
+	// debugger;
 	const oldData = this.getData();
 
 	this.data = newData;
-
-	if(!oldData.idUpdated && !newData.idUpdated){
-		newData.idUpdated = Date.now();
-		this.syncUp();
-	}
 
 	// If ID of this screen has changed, update the UI
 	if (newData.id && newData.id !== oldData.id) {
@@ -168,7 +78,7 @@ Viewer.prototype.update = function update(newData) {
 		return moment(a.dateTimeSchedule, 'x').isBefore(moment(b.dateTimeSchedule, 'x'));
 	});
 
-	this.saveData();
+	this.saveData(this.data, function(e){console.log(e);});
 };
 
 Viewer.prototype.getData = function getData(key) {
@@ -185,3 +95,126 @@ Viewer.prototype.syncUp = function syncUp() {
 Viewer.prototype.ready = function ready() {
 	return this.data.id && this.connectionState;
 };
+
+Viewer.prototype.poll = function(){
+		
+	const removeActiveFlag = () => {
+		this.data.items = this.data.items.map(function (item) {
+			item.active = false;
+			return item;
+		});
+	};
+	
+	const date = new Date();
+	date.setSeconds(0);
+	date.setMilliseconds(0);
+
+	this.amountOfItems = this.data.items.length;
+
+	this.data.items = this.data.items.filter(function(item) {
+		return (!item.expires || (new Date(item.expires)) > (new Date()));
+	});
+
+	const nextItem = (() => {
+
+		for (let i=0,l = this.data.items.length; i<l; i++) {
+			const item = this.data.items[i];
+
+			if (
+				moment(item.dateTimeSchedule, 'x').isBefore(date) ||
+				moment(item.dateTimeSchedule, 'x').isSame(date)
+			) {
+				return item;
+			}
+		}
+	})();
+
+	const newUrl = nextItem ? nextItem.url : undefined;
+
+	// Only update if the old url and new url are different
+	if (newUrl !== this.url) {
+		removeActiveFlag();
+		this.url = newUrl;
+		if (newUrl) {
+			nextItem.active = true;
+			this.emit('change', this.url);
+		} else {
+			if (this.ready()) {
+				this.emit('change', this.getDefaultUrl());
+			} else {
+				this.emit('not-connected');
+			}
+		}
+
+		this.syncUp();
+	} else if (this.amountOfItems !== this.data.items.length) {
+		this.syncUp();
+	}
+		
+}
+
+Viewer.prototype.startPolling = function(){
+
+	this.pollingInterval = setInterval(this.poll.bind(this), 1000);
+
+}
+
+Viewer.prototype.stopPolling = function(){
+	
+	clearInterval(this.pollingInterval);
+	
+}
+
+Viewer.prototype.bindSocketEvents = function(){
+	
+	const socket = io.connect(this.host + '/screens');
+	this.socket = socket;
+	
+	this.socket.on('requestUpdate', () => this.syncUp());
+
+	this.socket.on('update', data => {
+		console.log('Received update: ' + JSON.stringify(data, null, '  '));
+		this.update(data);
+	});
+
+	this.socket.on('reload', () => this.emit('reload'));
+
+	this.socket.on('connect', () => {
+		this.connectionState = true;
+		console.log("Connected");
+	});
+
+	this.socket.on('reassign', data => {
+
+		console.log('Reassign: ' + JSON.stringify(data, null, '  '));
+
+		const currentData = this.getData();
+
+		if (currentData.id === data.id && currentData.idUpdated === data.idUpdated) {
+
+			const newData = Object.assign({}, currentData);
+			newData.id = data.newID;
+
+			this.update(newData);
+			this.syncUp();
+		}
+
+	});
+	
+	this.socket.on('disconnect', () => {
+		this.socket.io.reconnect();
+		this.connectionState = false;
+	});
+
+	this.socket.on('heartbeat', function () {
+		// debugger;
+		setTimeout(function(){
+			// debugger;
+			this.emit('heartbeat');
+		}.bind(this), 3000);
+
+	});
+	
+	console.log('Initialising socket.io...');
+
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,14 +35,15 @@ function Viewer(host, storageOption) {
 util.inherits(Viewer, EventEmitter);
 
 Viewer.prototype.loadData = function loadData(callback) {
-	
+
 	this.dataStorage.getItem(this.dataStorage.dataKey, function(d){
+
 		if(d === null){
 			this.data = {'items':[]};
 		} else {
 			this.data = d;				
 		}
-		console.log(this.data, this);
+
 		callback(d);
 	}.bind(this) );
 	
@@ -55,8 +56,6 @@ Viewer.prototype.saveData = function saveData(data, callback) {
 module.exports = Viewer;
 
 Viewer.prototype.update = function update(newData) {
-
-	console.log("Update called");
 
 	const oldData = this.getData();
 
@@ -81,7 +80,7 @@ Viewer.prototype.update = function update(newData) {
 		return moment(a.dateTimeSchedule, 'x').isBefore(moment(b.dateTimeSchedule, 'x'));
 	});
 
-	this.saveData(this.data, function(e){console.log(e);});
+	this.saveData(this.data, function(e){console.log("Data saved.");});
 };
 
 Viewer.prototype.getData = function getData(key) {
@@ -90,7 +89,7 @@ Viewer.prototype.getData = function getData(key) {
 
 Viewer.prototype.syncUp = function syncUp() {
 	const storedData = this.getData();
-	this.saveData();
+	this.saveData(this.data, function(e){console.log("Data Saved.");});
 	console.log(`Syncing Up, ${storedData.items.length} items: ${JSON.stringify(storedData, null, '  ')}`);
 	this.socket.emit('update', storedData);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global io, dataStorage */
+/* global io */
 
 const moment = require('moment');
 const EventEmitter = require('events');
@@ -12,6 +12,10 @@ function Viewer(host, storageOption) {
 
 	this.host = host;
 	this.dataStorage = storageOption;
+	
+	if(this.dataStorage === undefined){
+		throw("You must pass a storage option.");
+	}
 	
 	if(this.dataStorage.dataKey === undefined || this.dataStorage.dataKey === ""){
 		this.dataStorage.dataKey = LSKEY;
@@ -27,15 +31,16 @@ function Viewer(host, storageOption) {
 
 	this.connectionState = false;
 }
+
 util.inherits(Viewer, EventEmitter);
 
 Viewer.prototype.loadData = function loadData(callback) {
 	
 	this.dataStorage.getItem(this.dataStorage.dataKey, function(d){
 		if(d === null){
-			this.data = {"items":[]};
+			this.data = {'items':[]};
 		} else {
-			this.data = JSON.parse(d["viewerData_v2"]);				
+			this.data = d;				
 		}
 		console.log(this.data, this);
 		callback(d);
@@ -44,9 +49,7 @@ Viewer.prototype.loadData = function loadData(callback) {
 }
 
 Viewer.prototype.saveData = function saveData(data, callback) {
-	// dataStorage.setItem(dataStorage.dataKey, JSON.stringify(this.data));
 	this.dataStorage.setItem(this.dataStorage.dataKey, data, callback);
-	
 }
 
 module.exports = Viewer;
@@ -54,7 +57,7 @@ module.exports = Viewer;
 Viewer.prototype.update = function update(newData) {
 
 	console.log("Update called");
-	// debugger;
+
 	const oldData = this.getData();
 
 	this.data = newData;
@@ -160,9 +163,7 @@ Viewer.prototype.startPolling = function(){
 }
 
 Viewer.prototype.stopPolling = function(){
-	
 	clearInterval(this.pollingInterval);
-	
 }
 
 Viewer.prototype.bindSocketEvents = function(){
@@ -207,14 +208,19 @@ Viewer.prototype.bindSocketEvents = function(){
 	});
 
 	this.socket.on('heartbeat', function () {
-		// debugger;
 		setTimeout(function(){
-			// debugger;
 			this.emit('heartbeat');
 		}.bind(this), 3000);
-
 	});
-	
+
 	console.log('Initialising socket.io...');
 
+}
+
+Viewer.prototype.start = function(){
+	this.loadData(function(){
+		this.bindSocketEvents();		
+		this.startPolling();
+		this.emit('ready', this.getDefaultUrl());
+	}.bind(this));
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ Viewer.prototype.loadData = function loadData(callback) {
 	this.dataStorage.getItem(this.dataStorage.dataKey, function(d){
 
 		if(d === null){
-			this.data = {'items':[]};
+			this.data = {items : []};
 		} else {
 			this.data = d;				
 		}

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,6 @@ function Viewer(host, storageOption) {
 	if(this.dataStorage.dataKey === undefined || this.dataStorage.dataKey === ""){
 		this.dataStorage.dataKey = LSKEY;
 	}
-	this.url;
 
 	// Returns the default url for generators, returns null if offline
 	this.getDefaultUrl = function getDefaultUrl() {

--- a/package.json
+++ b/package.json
@@ -20,14 +20,6 @@
     "mocha-phantomjs": "^4.0.1",
     "socket.io": "^1.3.7"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "transform-es2015-modules-commonjs"
-    ]
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftlabs-screens-viewer",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "description": "Connects to a screens server with websockets and fires events on url change.",
   "main": "./build/index.js",
   "scripts": {


### PR DESCRIPTION
screens-viewer now requires a data storage option to be passed in as an argument when creating a viewer. Any interface can be passed in, but should have the same interface as local storage (setItem/getItem) along with a callback that the data will be passed to. If the data store being used saves information as strings, it should be parsed as JSON before being passed back to screens-viewer.
