### PR TITLE
Make certain that we definitely have an ID before firing off the ready event.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global io */
+/* global io, window */
 
 const moment = require('moment');
 const EventEmitter = require('events');
@@ -227,9 +227,21 @@ Viewer.prototype.bindSocketEvents = function(){
 }
 
 Viewer.prototype.start = function(){
-	this.loadData(function(){
+	this.loadData(function(d){
 		this.bindSocketEvents();
 		this.startPolling();
-		this.emit('ready', this.getDefaultUrl());
+
+		if(d === null){
+			this.stateCheck = setInterval(function(){
+				if(this.getData('id') !== undefined){
+					window.clearTimeout(this.stateCheck);
+					console.log("ID is present. Emitting `ready` event...")
+					this.emit('ready', this.getDefaultUrl());
+				}
+			}.bind(this), 500);
+		} else {
+			this.emit('ready', this.getDefaultUrl());
+		}
+
 	}.bind(this));
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -234,8 +234,7 @@ Viewer.prototype.start = function(){
 		if(d === null){
 			this.stateCheck = setInterval(function(){
 				if(this.getData('id') !== undefined){
-					window.clearTimeout(this.stateCheck);
-					console.log("ID is present. Emitting `ready` event...")
+					window.clearInterval(this.stateCheck);
 					this.emit('ready', this.getDefaultUrl());
 				}
 			}.bind(this), 500);


### PR DESCRIPTION
On the very first boot of a Chromebit, it doesn’t have an ID so it reports its ID us `undefined` on the very first screen. In the meantime, it gets assigned an ID and stores that locally, but it doesn’t update the view to reflect that, because it only does so on a `reassign` event sent from our server
